### PR TITLE
feat: support for external signer

### DIFF
--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -7,6 +7,7 @@ import {
   TWO_POW256,
   unpadBuffer,
   ecsign,
+  splitSignature,
   publicToAddress,
   BNLike,
 } from '@exodus/ethereumjs-util'
@@ -296,6 +297,54 @@ export abstract class BaseTransaction<TransactionObject> {
     }
 
     return tx
+  }
+
+  /**
+   * Signs a transaction.
+   *
+   * Note that the signed tx is returned as a new object,
+   * use as follows:
+   * ```javascript
+   * const signer = (buffer: Buffer): Promise<{ signature, recid }>
+   * const signedTx = await tx.sign(signer)
+   * ```
+   */
+  signWithSigner(
+    signer: (msgHash: Buffer) => Promise<{ signature: Uint8Array; recid: number }>
+  ): Promise<TransactionObject> {
+    // Hack for the constellation that we have got a legacy tx after spuriousDragon with a non-EIP155 conforming signature
+    // and want to recreate a signature (where EIP155 should be applied)
+    // Leaving this hack lets the legacy.spec.ts -> sign(), verifySignature() test fail
+    // 2021-06-23
+    let hackApplied = false
+    if (
+      this.type === 0 &&
+      this.common.gteHardfork('spuriousDragon') &&
+      !this.supports(Capability.EIP155ReplayProtection)
+    ) {
+      this.activeCapabilities.push(Capability.EIP155ReplayProtection)
+      hackApplied = true
+    }
+
+    const msgHash = this.getMessageToSign(true)
+
+    const _processSignature = ({ signature, recid }: { signature: any; recid: number }) => {
+      const { r, s, v } = splitSignature(signature, recid)
+
+      const tx = this._processSignature(v, r, s)
+
+      // Hack part 2
+      if (hackApplied) {
+        const index = this.activeCapabilities.indexOf(Capability.EIP155ReplayProtection)
+        if (index > -1) {
+          this.activeCapabilities.splice(index, 1)
+        }
+      }
+
+      return tx
+    }
+
+    return signer(msgHash).then(({ signature, recid }) => _processSignature({ signature, recid }))
   }
 
   /**

--- a/packages/tx/test/index.ts
+++ b/packages/tx/test/index.ts
@@ -16,6 +16,7 @@ if (argv.b) {
 } else if (argv.a) {
   // All manual API tests
   require('./base.spec')
+  require('./signer.spec')
   require('./legacy.spec')
   require('./typedTxsAndEIP2930.spec')
   require('./eip1559.spec')
@@ -23,6 +24,7 @@ if (argv.b) {
 } else {
   require('./transactionRunner')
   require('./base.spec')
+  require('./signer.spec')
   require('./legacy.spec')
   require('./typedTxsAndEIP2930.spec')
   require('./eip1559.spec')

--- a/packages/tx/test/signer.spec.ts
+++ b/packages/tx/test/signer.spec.ts
@@ -1,0 +1,108 @@
+import tape from 'tape'
+import Common, { Chain, Hardfork } from '@exodus/ethereumjs-common'
+import {
+  Transaction,
+  AccessListEIP2930Transaction,
+  FeeMarketEIP1559Transaction,
+  N_DIV_2,
+  Capability,
+} from '../src'
+import { TxsJsonEntry } from './types'
+import { BaseTransaction } from '../src/baseTransaction'
+import { privateToPublic, BN, toBuffer } from '@exodus/ethereumjs-util'
+import { ecdsaSign } from '@exodus/secp256k1'
+
+tape('[BaseTransaction with signer]', function (t) {
+  // EIP-2930 is not enabled in Common by default (2021-03-06)
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
+
+  const legacyFixtures: TxsJsonEntry[] = require('./json/txs.json')
+  const legacyTxs: BaseTransaction<Transaction>[] = []
+  legacyFixtures.slice(0, 4).forEach(function (tx: TxsJsonEntry) {
+    legacyTxs.push(Transaction.fromTxData(tx.data, { common }))
+  })
+
+  const eip2930Fixtures = require('./json/eip2930txs.json')
+  const eip2930Txs: BaseTransaction<AccessListEIP2930Transaction>[] = []
+  eip2930Fixtures.forEach(function (tx: any) {
+    eip2930Txs.push(AccessListEIP2930Transaction.fromTxData(tx.data, { common }))
+  })
+
+  const eip1559Fixtures = require('./json/eip1559txs.json')
+  const eip1559Txs: BaseTransaction<FeeMarketEIP1559Transaction>[] = []
+  eip1559Fixtures.forEach(function (tx: any) {
+    eip1559Txs.push(FeeMarketEIP1559Transaction.fromTxData(tx.data, { common }))
+  })
+
+  const zero = Buffer.alloc(0)
+  const txTypes = [
+    {
+      class: Transaction,
+      name: 'Transaction',
+      type: 0,
+      values: Array(6).fill(zero),
+      txs: legacyTxs,
+      fixtures: legacyFixtures,
+      activeCapabilities: [],
+      notActiveCapabilities: [
+        Capability.EIP1559FeeMarket,
+        Capability.EIP2718TypedTransaction,
+        Capability.EIP2930AccessLists,
+        9999,
+      ],
+    },
+    {
+      class: AccessListEIP2930Transaction,
+      name: 'AccessListEIP2930Transaction',
+      type: 1,
+      values: [Buffer.from([1])].concat(Array(7).fill(zero)),
+      txs: eip2930Txs,
+      fixtures: eip2930Fixtures,
+      activeCapabilities: [Capability.EIP2718TypedTransaction, Capability.EIP2930AccessLists],
+      notActiveCapabilities: [Capability.EIP1559FeeMarket, 9999],
+    },
+    {
+      class: FeeMarketEIP1559Transaction,
+      name: 'FeeMarketEIP1559Transaction',
+      type: 2,
+      values: [Buffer.from([1])].concat(Array(8).fill(zero)),
+      txs: eip1559Txs,
+      fixtures: eip1559Fixtures,
+      activeCapabilities: [
+        Capability.EIP1559FeeMarket,
+        Capability.EIP2718TypedTransaction,
+        Capability.EIP2930AccessLists,
+      ],
+      notActiveCapabilities: [9999],
+    },
+  ]
+
+  t.test('signWithSigner()', async function (st) {
+    for (const txType of txTypes) {
+      let i = 0
+      for (const tx of txType.txs) {
+        const { privateKey } = txType.fixtures[i++]
+
+        if (privateKey) {
+          const signer = async (buffer: Buffer): Promise<any> => {
+            const s = ecdsaSign(buffer, Buffer.from(privateKey, 'hex'))
+            console.log(`${privateKey}`, {
+              signature: Buffer.from(s.signature).toString('hex'),
+              buffer: buffer.toString('hex'),
+              recid: s.recid,
+            })
+            return s
+          }
+
+          st.ok(await tx.signWithSigner(signer), `${txType.name}: should sign tx`)
+        }
+
+        st.throws(
+          () => tx.sign(Buffer.from('invalid')),
+          `${txType.name}: should fail with invalid PK`
+        )
+      }
+    }
+    st.end()
+  })
+})

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -26,7 +26,21 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: number): E
 export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId: BNLike): ECDSASignatureBuffer
 export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId: any): any {
   const { signature, recid: recovery } = ecdsaSign(msgHash, privateKey)
+  return splitSignature(signature, recovery, chainId)
+}
 
+/* eslint-disable no-redeclare */
+export function splitSignature(
+  signature: Uint8Array,
+  recovery: number,
+  chainId?: number
+): ECDSASignature
+export function splitSignature(
+  signature: Uint8Array,
+  recovery: number,
+  chainId: BNLike
+): ECDSASignatureBuffer
+export function splitSignature(signature: Uint8Array, recovery: number, chainId: any): Object {
   const r = Buffer.from(signature.slice(0, 32))
   const s = Buffer.from(signature.slice(32, 64))
 


### PR DESCRIPTION
Add support for external signer. This comes in handy when we keep the private key in a secluded process and/or don't want to expose the private key to any unnecessary libraries.

This PR should not be considered finished. The code is duplicated to show that the changes are minimal to existing functionality. It would probably make sense to reuse chunks of code.. Right now I'm interested in concept acknowledgement and suggestions on how to make the code merge-worthy.

Context: https://github.com/ExodusMovement/exodus-hydra/issues/5927